### PR TITLE
Fix incompatibility where some mods would spawn a grave when you didn't die

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@ All notable changes to this project will be documented in this file.
 - Added retry for gravestone item storage in case inventory is not initialized yet.
 - Improved death by explosion logic. 
 - Added more debug logs for future issues.
+
+## [1.0.3] - 20XX-XX-XX
+### Fixed
+- Enhanced compatibility with some mods that prevent your death in quirky ways. (See Ars Additions's Second Wind)

--- a/src/main/java/com/nouho/soulgravestone/events/DeathEvents.java
+++ b/src/main/java/com/nouho/soulgravestone/events/DeathEvents.java
@@ -53,20 +53,29 @@ public class DeathEvents {
         if (shouldCreate) {
             BlockPos gravestonePos = GravestoneManager.findGravestonePosition(player, level, deathPos);
             UUID playerUUID = player.getUUID();
+
+            // Pre-register the gravestone info with created=true assumption
+            // This will be updated by the delayed task
+            gravestoneInfoMap.put(player.getUUID(), new GravestoneInfo(gravestonePos, level, true));
             
             // Delay gravestone placement by 2 ticks to avoid destruction by explosions
             // Using a scheduled task ensures it runs after the explosion has finished
             level.getServer().tell(new net.minecraft.server.TickTask(
                 level.getServer().getTickCount() + 2,
                 () -> {
+                    // Some mods prevent your death not by preventing your death from occuring
+                    // (like a Totem of Undying preumably does), but by cancelling the LivingDeathEvent.
+                    // While this is kinda weird, it does work in Vanilla Minecraft,
+                    // so we should account for this happening.
+                    if (event.isCanceled()) {
+                        gravestoneInfoMap.put(player.getUUID(), new GravestoneInfo(deathPos, level, false));
+                        return;
+                    };
+
                     boolean created = GravestoneManager.createGravestone(player, level, gravestonePos);
                     gravestoneInfoMap.put(playerUUID, new GravestoneInfo(gravestonePos, level, created));
                 }
             ));
-            
-            // Pre-register the gravestone info with created=true assumption
-            // This will be updated by the delayed task
-            gravestoneInfoMap.put(player.getUUID(), new GravestoneInfo(gravestonePos, level, true));
         } else {
             // Should not create gravestone
             gravestoneInfoMap.put(player.getUUID(), new GravestoneInfo(deathPos, level, false));


### PR DESCRIPTION
Some mods prevent your death not by preventing your death from occuring  (like a Totem of Undying preumably does), but by cancelling the LivingDeathEvent. While this is kinda weird, it does work in Vanilla Minecraft so we should account for this happening.

The fake graves that would spawn even though you didn't die would still be spawned but be empty and only contain the XP it would if you died.

This was tested with [Ars Additions](https://modrinth.com/mod/ars-additions/)'s Second Wind item.